### PR TITLE
Eliminates hardcoded bash path

### DIFF
--- a/contrib/pass
+++ b/contrib/pass
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Sample wrapper program for simplying the use of keyringer.
 # This wrapper assumes you are using one key file with many

--- a/keyringer
+++ b/keyringer
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Keyringer key management system.
 #

--- a/lib/keyringer/actions/append
+++ b/lib/keyringer/actions/append
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Append information into encrypted files.
 #

--- a/lib/keyringer/actions/check
+++ b/lib/keyringer/actions/check
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Check a keyring.
 #

--- a/lib/keyringer/actions/commands
+++ b/lib/keyringer/actions/commands
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Show available commands
 #

--- a/lib/keyringer/actions/commit
+++ b/lib/keyringer/actions/commit
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Git commit wrapper.
 #

--- a/lib/keyringer/actions/cp
+++ b/lib/keyringer/actions/cp
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copy secrets.
 #

--- a/lib/keyringer/actions/decrypt
+++ b/lib/keyringer/actions/decrypt
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Decrypt files.
 #

--- a/lib/keyringer/actions/del
+++ b/lib/keyringer/actions/del
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Remove files.
 #

--- a/lib/keyringer/actions/edit
+++ b/lib/keyringer/actions/edit
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Edit keys.
 #

--- a/lib/keyringer/actions/encrypt
+++ b/lib/keyringer/actions/encrypt
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Encrypt files to multiple recipients.
 #

--- a/lib/keyringer/actions/find
+++ b/lib/keyringer/actions/find
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Find secrets.
 #

--- a/lib/keyringer/actions/genpair
+++ b/lib/keyringer/actions/genpair
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Generate keypairs.
 #

--- a/lib/keyringer/actions/git
+++ b/lib/keyringer/actions/git
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Git wrapper.
 #

--- a/lib/keyringer/actions/ls
+++ b/lib/keyringer/actions/ls
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # List keys.
 #

--- a/lib/keyringer/actions/mkdir
+++ b/lib/keyringer/actions/mkdir
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Create folders.
 #

--- a/lib/keyringer/actions/mv
+++ b/lib/keyringer/actions/mv
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Move secrets.
 #

--- a/lib/keyringer/actions/options
+++ b/lib/keyringer/actions/options
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Repository options management.
 #

--- a/lib/keyringer/actions/preferences
+++ b/lib/keyringer/actions/preferences
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Manipulate user preferences.
 #

--- a/lib/keyringer/actions/recipients
+++ b/lib/keyringer/actions/recipients
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Recipient management.
 #

--- a/lib/keyringer/actions/recrypt
+++ b/lib/keyringer/actions/recrypt
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Re-encrypt files to multiple recipients.
 #

--- a/lib/keyringer/actions/rmdir
+++ b/lib/keyringer/actions/rmdir
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Remove folders.
 #

--- a/lib/keyringer/actions/shell
+++ b/lib/keyringer/actions/shell
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Interactive shell.
 #

--- a/lib/keyringer/actions/teardown
+++ b/lib/keyringer/actions/teardown
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Remove a keyring.
 #

--- a/lib/keyringer/actions/tree
+++ b/lib/keyringer/actions/tree
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # List keys, tree version.
 #

--- a/lib/keyringer/actions/usage
+++ b/lib/keyringer/actions/usage
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Show available commands
 #

--- a/lib/keyringer/actions/xclip
+++ b/lib/keyringer/actions/xclip
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Decrypt secret header to clipboard.
 #

--- a/lib/keyringer/functions
+++ b/lib/keyringer/functions
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Common functions.
 #


### PR DESCRIPTION
Using /bin/bash won't work on many UNIX operating systems. This patch
changes it to use /usr/bin/env bash.